### PR TITLE
Add directory details to the package.json of all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "codesandboxer-repo",
   "version": "1.0.0",
   "description": "A simple react component to help easily deploy an example to codesandbox",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/codesandbox/codesandboxer"
+  },
   "scripts": {
     "test": "yarn jest",
     "build": "bolt ws run build",
@@ -85,7 +89,6 @@
     "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.4"
   },
-  "repository": "https://github.com/codesandbox/codesandboxer.git",
   "bolt": {
     "workspaces": [
       "packages/*"

--- a/packages/bitbucket-codesandboxer/package.json
+++ b/packages/bitbucket-codesandboxer/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.5",
   "private": true,
   "description": "Bitbucket addon for displaying releases section in PRs",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/codesandbox/codesandboxer",
+    "directory": "packages/bitbucket-codesandboxer"
+  },
   "scripts": {
     "dev": "webpack-dev-server --mode development",
     "build": "webpack -p",

--- a/packages/codesandboxer-fs/package.json
+++ b/packages/codesandboxer-fs/package.json
@@ -5,6 +5,11 @@
   "main": "index.js",
   "author": "Ben Conolly",
   "license": "MIT",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/codesandbox/codesandboxer",
+    "directory": "packages/codesandboxer-fs"
+  },
   "dependencies": {
     "codesandboxer": "^1.0.3",
     "meow": "^5.0.0",
@@ -19,6 +24,5 @@
   },
   "devDependencies": {
     "react-node-resolver": "^1.0.1"
-  },
-  "repository": "https://github.com/codesandbox/codesandboxer.git"
+  }
 }

--- a/packages/codesandboxer/package.json
+++ b/packages/codesandboxer/package.json
@@ -5,6 +5,11 @@
   "main": "dist/index.js",
   "author": "Ben Conolly",
   "license": "MIT",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/codesandbox/codesandboxer",
+    "directory": "packages/codesandboxer"
+  },
   "dependencies": {
     "path-browserify": "^1.0.0",
     "lz-string": "^1.4.4",
@@ -15,7 +20,6 @@
   "scripts": {
     "build": "babel src -d dist --ignore  **/*.test.js"
   },
-  "repository": "https://github.com/codesandbox/codesandboxer.git",
   "files": [
     "dist"
   ]

--- a/packages/react-codesandboxer/package.json
+++ b/packages/react-codesandboxer/package.json
@@ -5,6 +5,11 @@
   "main": "dist/index.js",
   "author": "Ben Conolly",
   "license": "MIT",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/codesandbox/codesandboxer",
+    "directory": "packages/react-codesandboxer"
+  },
   "dependencies": {
     "codesandboxer": "^1.0.3",
     "lodash.isequal": "^4.5.0",
@@ -14,7 +19,6 @@
   "scripts": {
     "build": "babel src -d dist --ignore  **/*.test.js"
   },
-  "repository": "https://github.com/codesandbox/codesandboxer.git",
   "files": [
     "dist"
   ]

--- a/packages/vs-codesandboxer/package.json
+++ b/packages/vs-codesandboxer/package.json
@@ -3,6 +3,11 @@
     "displayName": "vs-codesandboxer",
     "description": "upload to codesandbox from a single entry file",
     "version": "1.0.0",
+    "repository": {
+        "type" : "git",
+        "url" : "https://github.com/codesandbox/codesandboxer",
+        "directory": "packages/vs-codesandboxer"
+    },
     "publisher": "noviny",
     "engines": {
         "vscode": "^1.23.0"
@@ -11,7 +16,6 @@
         "onCommand:extension.vs-codesandboxer"
     ],
     "main": "./extension",
-    "repository": "https://github.com/codesandbox/codesandboxer.git",
     "contributes": {
         "commands": [
             {


### PR DESCRIPTION
Just like codesandbox/codesandbox-client#2167

Specifying the directory as part of the `repository` field in a `package.json` allows third party tools to provide better support when working with monorepos. For example, it allows them to correctly construct a commit diff for a specific package.

This format was accepted by `npm` in npm/rfcs#19.